### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JosunLP/sort-it-now/security/code-scanning/1](https://github.com/JosunLP/sort-it-now/security/code-scanning/1)

To resolve this issue, add an explicit `permissions:` block to the workflow to restrict the GitHub Actions token to the minimal required privileges. Since the job does not interact with releases, issues, or pull requests, and only needs to read the repository contents, set `permissions: contents: read` at the workflow root, right after the `name:` key and before `on:`. This makes the least privilege explicit and will apply to all jobs in the workflow.

No other imports, methods, or variable definitions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
